### PR TITLE
Fix broken links and ignore template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribute to NEST
 
-The NEST Simulator is a scientific tool and as such it is never finished and constantly changing to meet the needs of novel neuroscientific endeavors. Here you find the most important information on how you can contribute to NEST. This document is an excerpt from our [Contributing to NEST documentation](https://nest-simulator.readthedocs.io/en/latest/contribute/index.html), which provides more detailed information.
+The NEST Simulator is a scientific tool and as such it is never finished and constantly changing to meet the needs of novel neuroscientific endeavors. Here you find the most important information on how you can contribute to NEST. This document is an excerpt from our [Contributing to NEST documentation](https://nest-simulator.readthedocs.io/en/latest/developer_space/index.html), which provides more detailed information.
 
 
 * Make sure you have a [GitHub account](https://github.com/signup/free)

--- a/doc/htmldoc/static/css/custom.css
+++ b/doc/htmldoc/static/css/custom.css
@@ -388,12 +388,6 @@ width: 85%;
 	padding-left: 0;
 	padding-right: 0;
 }
-.scbs-carousel-control-next-icon{
-  background-image: url('../img/arrow_right.svg')
-}
-.scbs-carousel-control-prev-icon{
-  background-image: url('../img/arrow_left.svg')
-}
 .sd-tab-set > input:checked + label {
 
   border-color: var(--nest-orange) !important;

--- a/doc/htmldoc/static/js/flexslider/flexslider.css
+++ b/doc/htmldoc/static/js/flexslider/flexslider.css
@@ -21,7 +21,7 @@
 
 /* FlexSlider Necessary Styles
 *********************************/
-.flexslider {margin: 0; padding: 0; min-height:150px; background:url(images/loader.gif) no-repeat center center;}
+.flexslider {margin: 0; padding: 0; min-height:150px;}
 .flexslider .slides > li {display: none; -webkit-backface-visibility: hidden;} /* Hide the slides before the JS is loaded. Avoids image jumping */
 .flexslider .slides img {width: 100%; display: block;}
 .flex-pauseplay span {text-transform: capitalize;}
@@ -51,7 +51,7 @@ html[xmlns] .slides {display: block;}
 
 /* Direction Nav */
 .flex-direction-nav {*height: 0;}
-.flex-direction-nav a {width: 30px; height: 30px; margin: -20px 0 0; display: block; background: url(images/bg_direction_nav.png) no-repeat 0 0; position: absolute; top: 50%; z-index: 10; cursor: pointer; text-indent: -9999px; opacity: 0; -webkit-transition: all .3s ease;}
+.flex-direction-nav a {width: 30px; height: 30px; margin: -20px 0 0; display: block; position: absolute; top: 50%; z-index: 10; cursor: pointer; text-indent: -9999px; opacity: 0; -webkit-transition: all .3s ease;}
 .flex-direction-nav .flex-next {background-position: 100% 0; opacity: 0.8; right: 5px;}
 .flex-direction-nav .flex-prev {opacity: 0.8; left: 5px;}
 .flexslider:hover .flex-next:hover, .flexslider:hover .flex-prev:hover {opacity: 1;}

--- a/lychee.toml
+++ b/lychee.toml
@@ -46,6 +46,12 @@ method = "get"
 # Exclude URLs from checking (supports regex)
 exclude = [".git/.*"]
 
+# Exclude input paths from checking (supports glob).
+# The Sphinx/Jinja2 HTML templates contain unrendered `{{ pathto(...) }}`
+# expressions that are only resolved at doc build time. Checking the raw
+# template source reports these as broken local files, so skip it.
+exclude_path = ["doc/htmldoc/templates"]
+
 # Exclude URLs contained in a file from checking
 # If a file named `.lycheeignore` exists in the current working directory,
 # its contents will be excluded as well.


### PR DESCRIPTION
Fix the broken links
note that lychee reported errors in the template folder even though those images were present and working. This is due to the template resolving at build time, so I think ignoring this folder is ok